### PR TITLE
Added async/await to fix firefox issue + other things

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         - ./headsup.sql:/docker-entrypoint-initdb.d/init.sql:ro
         - ./database/:/var/lib/mysql
     ports:
-      - "F33060:3306"
+      - "33060:3306"
     environment:
         TZ: "America/New York"
         MYSQL_ROOT_PASSWORD: "root"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         - ./headsup.sql:/docker-entrypoint-initdb.d/init.sql:ro
         - ./database/:/var/lib/mysql
     ports:
-      - "33060:3306"
+      - "F33060:3306"
     environment:
         TZ: "America/New York"
         MYSQL_ROOT_PASSWORD: "root"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headsup",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headsup",
-  "version": "2.0.2",
+  "version": "1.1.2",
   "description": "RPIA's digital whiteboard system",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headsup",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "RPIA's digital whiteboard system",
   "main": "server.js",
   "scripts": {

--- a/public/admin.html
+++ b/public/admin.html
@@ -92,6 +92,7 @@
         </form>
       </div>
     </div>
+  </div>
 </body>
 <script type="text/javascript" src="public/js/admin.js"></script>
 </html>

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -27,27 +27,13 @@ async function getNotes() {
 // eslint-disable-next-line
 async function createNote() {
     const note = document.querySelector('#add-a-note').value;
-    await fetch('/note/create', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        redirect: 'follow',
-        body: JSON.stringify({ note })
-    });
+    await postServer('/note/create',note);
     window.location.reload();
 }
 
 // eslint-disable-next-line
 async function deleteNote(note_id) {
-    await fetch('/note/delete', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        redirect: 'follow',
-        body: JSON.stringify({ note: note_id })
-    });
+    await postServer('/note/delete', {note: note_id});
     document.querySelector('#notes').innerHTML = '';
     getNotes();
 }
@@ -71,15 +57,19 @@ async function addCall() {
     const category = document.querySelector('#category').value;
     const response = document.querySelector('#response').value;
     const call_data = { prid, cc, driver, category, response };
-    await fetch('/call/create', {
+    await postServer('/call/create',call_data);
+    window.location.reload();
+}
+
+async function postServer(endpoint,body) {
+    await fetch(endpoint, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },
         redirect: 'follow',
-        body: JSON.stringify(call_data)
+        body: JSON.stringify(body)
     });
-    window.location.reload();
 }
 
 getNotes();

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1,5 +1,6 @@
 async function getNotes() {
     const response = await fetch('/notes');
+    checkResult(response);
     const notes = (await response.json()).data;
     let html = '';
     if (notes.length !== 0) {
@@ -27,19 +28,21 @@ async function getNotes() {
 // eslint-disable-next-line
 async function createNote() {
     const note = document.querySelector('#add-a-note').value;
-    await postServer('/note/create',note);
-    window.location.reload();
+    if (note === '') return;
+    await postToServer('/note/create', {note: note});
+    document.querySelector('#add-a-note').value = '';
+    await getNotes();
 }
 
 // eslint-disable-next-line
 async function deleteNote(note_id) {
-    await postServer('/note/delete', {note: note_id});
-    document.querySelector('#notes').innerHTML = '';
-    getNotes();
+    await postToServer('/note/delete', {note: note_id});
+    await getNotes();
 }
 
 async function generateCategoryDropdown() {
     const response = await fetch('/public/js/call-categories.json');
+    checkResult(response);
     const categories = await response.json();
     for (const category of categories) {
         const option = document.createElement('option');
@@ -57,12 +60,16 @@ async function addCall() {
     const category = document.querySelector('#category').value;
     const response = document.querySelector('#response').value;
     const call_data = { prid, cc, driver, category, response };
-    await postServer('/call/create',call_data);
-    window.location.reload();
+    await postToServer('/call/create',call_data);
+    document.querySelector('#prid').value = '';
+    document.querySelector('#tic').value = '';
+    document.querySelector('#driver').value = '';
+    document.querySelector('#category').value = '';
+    document.querySelector('#response').value = '';
 }
 
-async function postServer(endpoint,body) {
-    await fetch(endpoint, {
+async function postToServer(endpoint, body) {
+    const response = await fetch(endpoint, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -70,6 +77,13 @@ async function postServer(endpoint,body) {
         redirect: 'follow',
         body: JSON.stringify(body)
     });
+    checkResult(response);
+}
+
+function checkResult(response) {
+    if (!response.ok) {
+        throw response.statusText;
+    }
 }
 
 getNotes();

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -25,9 +25,9 @@ async function getNotes() {
 }
 
 // eslint-disable-next-line
-function createNote() {
+async function createNote() {
     const note = document.querySelector('#add-a-note').value;
-    fetch('/note/create', {
+    await fetch('/note/create', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -71,7 +71,7 @@ async function addCall() {
     const category = document.querySelector('#category').value;
     const response = document.querySelector('#response').value;
     const call_data = { prid, cc, driver, category, response };
-    fetch('/call/create', {
+    await fetch('/call/create', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'


### PR DESCRIPTION
Fixes Firefox issue of not adding calls/notes.
Prevent notes from being empty;
Removed window reload upon adding note/call;
Added form reset on adding a note/call;
Added refresh of notes on adding a call;
Added await to getNotes in deleteCall();
Added `</div>` that was missing in the admin.html

Currently the reset of the addCall causes the validator to run (this occurs even with reloading the page). This will need to be looked into for Firefox.