### PR TITLE
Update GH workflow to use new pr version check action

### DIFF
--- a/.github/workflows/master-pr-check-version.yml
+++ b/.github/workflows/master-pr-check-version.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-
-    - run: git pull origin/master
       
     - name: Check if version changed
       uses: rpiambulance/action-pr-version-check@master

--- a/.github/workflows/master-pr-check-version.yml
+++ b/.github/workflows/master-pr-check-version.yml
@@ -12,5 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - run: git pull origin/master
+      
     - name: Check if version changed
       uses: rpiambulance/action-pr-version-check@master

--- a/.github/workflows/master-pr-check-version.yml
+++ b/.github/workflows/master-pr-check-version.yml
@@ -10,40 +10,7 @@ jobs:
   master-pr-check-version:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
     - name: Check if version changed
-      run: |
-        check_versions() {
-          git diff origin/master package.json | grep version
-        }
-
-        version_changed=`check_versions | wc -l | tr -d '[:space:]'`
-
-        if [ $version_changed -gt 1 ]; then
-          echo "Versions are different; verifying that the version increased"
-          check_versions
-          version_increased=`check_versions | awk -F\" '{
-            split($4, old, ".");
-            getline;
-            split($4, new, ".");
-            if(new[1] > old[1] \
-              || (new[1] == old[1] && new[2] > old[2]) \
-              || (new[1] == old[1] && new[2] == old[2] && new[3] > old[3])) {
-
-              print 1
-            } else {
-              print 0
-            }
-          }'`
-
-          if [ $version_increased -eq 1 ]; then
-            echo "Version is properly increased!"
-            exit 0
-          else
-            echo "Version is not properly increased; failing..."
-            exit 1
-          fi
-        else
-          echo "Version has not been modified; failing..."
-          exit 1
-        fi
+      uses: rpiambulance/action-pr-version-check@master

--- a/.github/workflows/master-pr-check-version.yml
+++ b/.github/workflows/master-pr-check-version.yml
@@ -10,7 +10,7 @@ jobs:
   master-pr-check-version:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
 
     - name: Check if version changed
       uses: rpiambulance/action-pr-version-check@master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headsup",
-  "version": "1.2.1",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headsup",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "RPIA's digital whiteboard system",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
Update to use https://github.com/rpiambulance/action-pr-version-check to handle checking that a PR updates the version when made against master.